### PR TITLE
Solid highlight for archive card

### DIFF
--- a/styles/Archiveitem.module.scss
+++ b/styles/Archiveitem.module.scss
@@ -9,7 +9,7 @@
 }
 
 .main:hover {
-  box-shadow: 0px 0px 5px 10px #ffbd3f;
+  box-shadow: 0px 0px 0px 10px #ffbd3f;
 }
 
 .main li {


### PR DESCRIPTION
Make the archive card highlighting not blurry

## Before
https://github.com/uclaacm/cyber.uclaacm.com/assets/50760816/70a50ea8-e417-4178-82f1-de276cd73093

## After
https://github.com/uclaacm/cyber.uclaacm.com/assets/50760816/17491ed1-4e14-4e20-be5a-f39e40006cd5



