### PR TITLE
Fix syntax highlight

### DIFF
--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import * as fs from "node:fs/promises";
 import path from "node:path";
 // @ts-ignore
@@ -53,25 +54,33 @@ export default function Post({ postData }: { postData: PostData }) {
     hljs.highlightAll();
   }, []);
   return (
-    <div className={`page ${styles.post}`}>
-      <div className={styles.categorydate}>
-        <p className={styles.alignleft}>{postData.category}</p>
-        <p className={styles.alignright}>{postData.date}</p>
-      </div>
-      <h1>{postData.title}</h1>
-      <img
-        src="https://www.theforage.com/blog/wp-content/uploads/2022/12/what-is-cybersecurity.jpg"
-        alt="blog image"
-      />
-      <div>
-        <p>
-          <i>Written by {postData.authors.join(", ")}</i>
-        </p>
-        <p className={styles.tags}>Tags: {postData.tags.join(", ")}</p>
-        <div className={styles.postContent}>
-          <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
+    <>
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/monokai-sublime.min.css"
+        />
+      </Head>
+      <div className={`page ${styles.post}`}>
+        <div className={styles.categorydate}>
+          <p className={styles.alignleft}>{postData.category}</p>
+          <p className={styles.alignright}>{postData.date}</p>
+        </div>
+        <h1>{postData.title}</h1>
+        <img
+          src="https://www.theforage.com/blog/wp-content/uploads/2022/12/what-is-cybersecurity.jpg"
+          alt="blog image"
+        />
+        <div>
+          <p>
+            <i>Written by {postData.authors.join(", ")}</i>
+          </p>
+          <p className={styles.tags}>Tags: {postData.tags.join(", ")}</p>
+          <div className={styles.postContent}>
+            <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,8 +1,6 @@
 @import "https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Nova+Mono&display=swap";
 @import "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap";
-@import "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/monokai-sublime.min.css";
-// @import "prismjs/themes/prism-dark.min.css";
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
Use `<Head />` from nextjs to fix the syntax highlighting.

Locally, everything works when I do `yarn dev`, but its all goofed up when I do `yarn build && yarn next export`. I think it has something to do with the fact that production builds rely on files in cyber.uclaacm.com instead of just relative paths.
