### PR TITLE
fix: missing 404 config within `next.config.js`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,7 @@ const nextConfig = {
       "/events": { page: "/events" },
       "/archive": { page: "/archive" },
       "/blog": { page: "/blog" },
+      "/404": { page: "/404" },
       ...(debug
         ? {
             _next: { page: "_next" },


### PR DESCRIPTION
`next.config.js` was missing details to properly build and export the custom 404 page in `404.js`. This adds the missing config details.